### PR TITLE
fix: pin dependencies to exact versions and add CI + Renovate pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install dependencies
+        run: poetry install --extras watch
+
+      - name: Lint
+        run: poetry run ruff check .
+
+      - name: Format check
+        run: poetry run ruff format --check .
+
+      - name: Tests
+        run: poetry run pytest -v

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: renovatebot/github-action@v41
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          configurationFile: renovate.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,13 @@ poetry run ruff format --check .  # check format without modifying
 - The subprocess target function (`_run_handler_in_process`) must be defined at module level (required by multiprocessing).
 - Exception propagation from subprocess uses string tuples `("error", type_name, message, traceback_str, elapsed)`, never raw exception objects.
 
+## Dependency Security
+
+- **Always use exact version pins (`==`)** in `pyproject.toml`. Never use `>=`, `^`, or `~`.
+- **Renovate** handles dependency updates via PRs with a 3-day minimum release age (`minimumReleaseAge`). Never update dependencies manually — let Renovate create the PR and review it before merging.
+- **`poetry.lock` must always be committed.** It contains SHA256 hashes that prevent tampered packages from being installed.
+- When adding a new dependency, pin it to the exact version installed: `poetry show <package>` to get the version, then add `package = "==X.Y.Z"` to `pyproject.toml`.
+
 ## Known Pitfalls
 
 - `importlib.import_module()` caches modules in `sys.modules`. With multiprocessing + fork, the subprocess inherits the parent's module cache.

--- a/poetry.lock
+++ b/poetry.lock
@@ -408,4 +408,4 @@ watch = ["watchfiles"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "e09b58aac5072317f86769468ae35acfb97bbd4510204d5c291549b16c32e9ea"
+content-hash = "022772614f5fae29deaa2c29897ec1e6cdfa632ffd9a577ff86e6f17e61805c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,16 +20,16 @@ lambdarunner = "lambdarunner.cli:app"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-typer = ">=0.9.0"
-rich = ">=13.0.0"
-watchfiles = {version = ">=0.20.0", optional = true}
+typer = "==0.24.1"
+rich = "==14.3.3"
+watchfiles = {version = "==1.1.1", optional = true}
 
 [tool.poetry.extras]
 watch = ["watchfiles"]
 
 [tool.poetry.group.dev.dependencies]
-pytest = ">=8.0.0"
-ruff = ">=0.4.0"
+pytest = "==9.0.2"
+ruff = "==0.15.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "3 days",
+  "rangeStrategy": "pin",
+  "labels": ["dependencies"],
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 5,
+  "automerge": false,
+  "packageRules": [
+    {
+      "matchManagers": ["poetry"],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
  - Pin all dependencies to exact versions (`==`) to prevent supply chain attacks                                                                                                                                    
  - Add CI pipeline with Python 3.12, 3.13, 3.14 matrix (lint + format + tests)                                                                                                                                      
  - Add self-hosted Renovate workflow for automated dependency update PRs                                                                                                                                            
    - 3-day minimum release age before proposing updates                                                                                                                                                             
    - No automerge — all PRs require manual review                                                                                                                                                                   
    - Weekly schedule (Monday 4AM UTC) + manual trigger                                                                                                                                                              
                                                                                                                                                                                                                     
  ## Changed files                                                                                                                                                                                                   
  - `pyproject.toml` — exact pins for typer, rich, watchfiles, pytest, ruff                                                                                                                                          
  - `.github/workflows/ci.yml` — test + lint pipeline                                                                                                                                                                
  - `.github/workflows/renovate.yml` — self-hosted Renovate                                                                                                                                                          
  - `renovate.json` — Renovate configuration                                                                                                                                                                         
  - `CLAUDE.md` — dependency security rules                                                                                                                                                                          
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                   
  - [ ] `poetry install --extras watch` resolves correctly                                                                                                                                                           
  - [ ] `poetry run pytest -v` — 30 tests pass                                                                                                                                                                       
  - [ ] Actions → Renovate → "Run workflow" creates dependency PRs                                                                                                                                                   
  - [ ] CI triggers on PRs to main    