### PR TITLE
feat: add template command for AWS Lambda event templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,38 @@ Watch mode requires: `pip install lambdarunner[watch]`
 
 Mock AWS mode requires: `pip install lambdarunner[mock]`
 
+## Event Templates
+
+Generate ready-to-use event JSON for the most common Lambda trigger types:
+
+```bash
+# List all available templates
+lambdarunner template
+
+# Print a template to the terminal
+lambdarunner template s3
+lambdarunner template sqs
+lambdarunner template sns
+lambdarunner template eventbridge
+lambdarunner template apigw       # API Gateway REST API (v1)
+lambdarunner template apigw-v2    # API Gateway HTTP API (v2)
+```
+
+Save to file and use with `invoke`:
+
+```bash
+# Bash / Zsh (Linux, macOS)
+lambdarunner template s3 > event.json
+lambdarunner invoke handler.lambda_handler --event event.json
+
+# PowerShell 7 (pwsh)
+lambdarunner template s3 > event.json
+
+# PowerShell 5 (Windows PowerShell)
+# Use Out-File to ensure UTF-8 encoding (plain `>` produces UTF-16 in PS5)
+lambdarunner template s3 | Out-File -Encoding utf8 event.json
+```
+
 ## CLI Options
 
 | Flag | Short | Default | Description |

--- a/lambdarunner/cli.py
+++ b/lambdarunner/cli.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
+from rich.table import Table
 
 from lambdarunner import __version__
 from lambdarunner.loader import load_env_file
@@ -272,6 +273,35 @@ def invoke_cmd(
             )
     except KeyboardInterrupt:
         console.print("\n[dim]Watch mode stopped.[/dim]")
+
+
+@app.command("template")
+def template_cmd(
+    event_type: Annotated[
+        str | None,
+        typer.Argument(help="Event type (s3, sqs, sns, eventbridge, apigw, apigw-v2)"),
+    ] = None,
+) -> None:
+    """List available AWS event templates or print one as JSON."""
+    from lambdarunner.templates import get_template, list_templates
+
+    if event_type is None:
+        table = Table(title="AWS Lambda event templates", border_style="cyan")
+        table.add_column("Type", style="cyan bold")
+        table.add_column("Description")
+        for name, description in list_templates():
+            table.add_row(name, description)
+        console.print(table)
+        return
+
+    try:
+        template = get_template(event_type)
+    except ValueError as exc:
+        err_console.print(Panel(f"[red]{exc}[/red]", title="Error", border_style="red"))
+        raise typer.Exit(1) from None
+
+    formatted = json.dumps(template, indent=2, ensure_ascii=False)
+    console.print(Syntax(formatted, "json", theme="monokai"))
 
 
 if __name__ == "__main__":

--- a/lambdarunner/runner.py
+++ b/lambdarunner/runner.py
@@ -54,7 +54,7 @@ def parse_event(event_input: str) -> Any:
 
     path = Path(event_input)
     if path.exists() and path.is_file():
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8-sig"))
 
     return json.loads(event_input)
 

--- a/lambdarunner/templates.py
+++ b/lambdarunner/templates.py
@@ -1,0 +1,215 @@
+"""Event templates for common AWS Lambda trigger sources."""
+
+from copy import deepcopy
+from typing import Any
+
+_TEMPLATE_DESCRIPTIONS: dict[str, str] = {
+    "s3": "S3 ObjectCreated:Put event",
+    "sqs": "SQS message event (1 record)",
+    "sns": "SNS Notification event (1 record)",
+    "eventbridge": "EventBridge custom event",
+    "apigw": "API Gateway REST API (v1) proxy event",
+    "apigw-v2": "API Gateway HTTP API (v2) proxy event",
+}
+
+_EVENT_TEMPLATES: dict[str, dict[str, Any]] = {
+    "s3": {
+        "Records": [
+            {
+                "eventVersion": "2.1",
+                "eventSource": "aws:s3",
+                "awsRegion": "us-east-1",
+                "eventTime": "2024-01-01T00:00:00.000Z",
+                "eventName": "ObjectCreated:Put",
+                "userIdentity": {"principalId": "EXAMPLE"},
+                "requestParameters": {"sourceIPAddress": "127.0.0.1"},
+                "responseElements": {
+                    "x-amz-request-id": "EXAMPLE123456789",
+                    "x-amz-id-2": "EXAMPLE123/abc/mnopqrstuvwxyzABCDEFGH",
+                },
+                "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "configurationId": "testConfigRule",
+                    "bucket": {
+                        "name": "my-bucket",
+                        "ownerIdentity": {"principalId": "EXAMPLE"},
+                        "arn": "arn:aws:s3:::my-bucket",
+                    },
+                    "object": {
+                        "key": "my-key.txt",
+                        "size": 1024,
+                        "eTag": "0123456789abcdef0123456789abcdef",
+                        "sequencer": "0A1B2C3D4E5F678901",
+                    },
+                },
+            }
+        ]
+    },
+    "sqs": {
+        "Records": [
+            {
+                "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+                "receiptHandle": "AQEBwJnKyrHigUMZj6reyNurzbEivf...",
+                "body": "Hello World",
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1703116800000",
+                    "SenderId": "123456789012",
+                    "ApproximateFirstReceiveTimestamp": "1703116800001",
+                },
+                "messageAttributes": {},
+                "md5OfBody": "e1d7a5a46cf7a5b9b369eb06f1d26e41",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+                "awsRegion": "us-east-1",
+            }
+        ]
+    },
+    "sns": {
+        "Records": [
+            {
+                "EventVersion": "1.0",
+                "EventSubscriptionArn": "arn:aws:sns:us-east-1:123456789012:Topic:sub",
+                "EventSource": "aws:sns",
+                "Sns": {
+                    "SignatureVersion": "1",
+                    "Timestamp": "2024-01-01T00:00:00.000Z",
+                    "Signature": "EXAMPLE",
+                    "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-abc.pem",
+                    "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+                    "Message": "Hello World",
+                    "MessageAttributes": {
+                        "myAttribute": {
+                            "Type": "String",
+                            "Value": "myValue",
+                        }
+                    },
+                    "Type": "Notification",
+                    "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=...",
+                    "TopicArn": "arn:aws:sns:us-east-1:123456789012:MyTopic",
+                    "Subject": "My Subject",
+                },
+            }
+        ]
+    },
+    "eventbridge": {
+        "version": "0",
+        "id": "12345678-1234-1234-1234-123456789012",
+        "source": "my.custom.source",
+        "account": "123456789012",
+        "time": "2024-01-01T00:00:00Z",
+        "region": "us-east-1",
+        "resources": [],
+        "detail-type": "MyCustomEvent",
+        "detail": {"key": "value"},
+    },
+    "apigw": {
+        "httpMethod": "GET",
+        "path": "/hello",
+        "resource": "/hello",
+        "queryStringParameters": None,
+        "multiValueQueryStringParameters": None,
+        "headers": {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Host": "api.example.com",
+        },
+        "multiValueHeaders": {
+            "Accept": ["application/json"],
+        },
+        "pathParameters": None,
+        "stageVariables": None,
+        "requestContext": {
+            "accountId": "123456789012",
+            "apiId": "1234567890",
+            "authorizer": None,
+            "domainName": "1234567890.execute-api.us-east-1.amazonaws.com",
+            "domainPrefix": "1234567890",
+            "extendedRequestId": "abc123def456=",
+            "httpMethod": "GET",
+            "identity": {
+                "accessKey": None,
+                "accountId": None,
+                "caller": None,
+                "cognitoAuthenticationProvider": None,
+                "cognitoAuthenticationType": None,
+                "cognitoIdentityId": None,
+                "cognitoIdentityPoolId": None,
+                "principalOrgId": None,
+                "sourceIp": "127.0.0.1",
+                "user": None,
+                "userAgent": "Custom User Agent String",
+                "userArn": None,
+            },
+            "path": "/hello",
+            "protocol": "HTTP/1.1",
+            "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+            "requestTime": "01/Jan/2024:00:00:00 +0000",
+            "requestTimeEpoch": 1704067200000,
+            "resourceId": None,
+            "resourcePath": "/hello",
+            "stage": "dev",
+        },
+        "body": None,
+        "isBase64Encoded": False,
+    },
+    "apigw-v2": {
+        "version": "2.0",
+        "routeKey": "GET /hello",
+        "rawPath": "/hello",
+        "rawQueryString": "",
+        "cookies": [],
+        "headers": {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "host": "api.example.com",
+        },
+        "queryStringParameters": None,
+        "pathParameters": None,
+        "stageVariables": None,
+        "requestContext": {
+            "accountId": "123456789012",
+            "apiId": "api-id",
+            "domainName": "api.example.com",
+            "domainPrefix": "api",
+            "http": {
+                "method": "GET",
+                "path": "/hello",
+                "protocol": "HTTP/1.1",
+                "sourceIp": "127.0.0.1",
+                "userAgent": "Custom User Agent",
+            },
+            "authorizer": None,
+            "requestId": "JKJaXmPLvHcESHA=",
+            "routeKey": "GET /hello",
+            "stage": "$default",
+            "time": "01/Jan/2024:00:00:00 +0000",
+            "timeEpoch": 1704067200000,
+        },
+        "body": None,
+        "isBase64Encoded": False,
+    },
+}
+
+
+def list_templates() -> list[tuple[str, str]]:
+    """Return (name, description) pairs for all available event templates."""
+    return [(name, _TEMPLATE_DESCRIPTIONS[name]) for name in _EVENT_TEMPLATES]
+
+
+def get_template(name: str) -> dict[str, Any]:
+    """Return a deep copy of the named AWS event template.
+
+    Args:
+        name: Template name (e.g. 's3', 'sqs', 'apigw-v2').
+
+    Returns:
+        A copy of the event template dict.
+
+    Raises:
+        ValueError: If the template name is not recognized.
+    """
+    if name not in _EVENT_TEMPLATES:
+        available = ", ".join(_EVENT_TEMPLATES)
+        raise ValueError(f"Unknown template: {name!r}. Available: {available}")
+    return deepcopy(_EVENT_TEMPLATES[name])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,74 @@
+"""Tests for the CLI commands."""
+
+from typer.testing import CliRunner
+
+from lambdarunner.cli import app
+
+runner = CliRunner()
+
+
+class TestVersionFlag:
+    def test_version_flag(self):
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "lambdarunner" in result.output
+
+    def test_version_short_flag(self):
+        result = runner.invoke(app, ["-V"])
+        assert result.exit_code == 0
+        assert "lambdarunner" in result.output
+
+
+class TestTemplateCommand:
+    def test_no_args_lists_all_types(self):
+        result = runner.invoke(app, ["template"])
+        assert result.exit_code == 0
+        for event_type in ("s3", "sqs", "sns", "eventbridge", "apigw", "apigw-v2"):
+            assert event_type in result.output
+
+    def test_no_args_shows_descriptions(self):
+        result = runner.invoke(app, ["template"])
+        assert result.exit_code == 0
+        assert "S3" in result.output
+        assert "SQS" in result.output
+
+    def test_s3_shows_json(self):
+        result = runner.invoke(app, ["template", "s3"])
+        assert result.exit_code == 0
+        assert "aws:s3" in result.output
+        assert "ObjectCreated:Put" in result.output
+
+    def test_sqs_shows_json(self):
+        result = runner.invoke(app, ["template", "sqs"])
+        assert result.exit_code == 0
+        assert "aws:sqs" in result.output
+
+    def test_sns_shows_json(self):
+        result = runner.invoke(app, ["template", "sns"])
+        assert result.exit_code == 0
+        assert "aws:sns" in result.output
+
+    def test_eventbridge_shows_json(self):
+        result = runner.invoke(app, ["template", "eventbridge"])
+        assert result.exit_code == 0
+        assert "detail-type" in result.output
+
+    def test_apigw_shows_json(self):
+        result = runner.invoke(app, ["template", "apigw"])
+        assert result.exit_code == 0
+        assert "httpMethod" in result.output
+
+    def test_apigw_v2_shows_json(self):
+        result = runner.invoke(app, ["template", "apigw-v2"])
+        assert result.exit_code == 0
+        assert "routeKey" in result.output
+        assert "2.0" in result.output
+
+    def test_unknown_type_exits_with_error(self):
+        result = runner.invoke(app, ["template", "unknown-source"])
+        assert result.exit_code == 1
+
+    def test_unknown_type_shows_error_message(self):
+        result = runner.invoke(app, ["template", "kinesis"])
+        assert result.exit_code == 1
+        assert "Unknown template" in result.output or "kinesis" in result.output

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -53,6 +53,13 @@ class TestParseEvent:
         result = parse_event("-")
         assert result == {"source": "stdin"}
 
+    def test_from_file_with_bom(self, tmp_path):
+        """UTF-8 BOM files (e.g. from PowerShell 5 Out-File) should parse correctly."""
+        event_file = tmp_path / "event.json"
+        event_file.write_bytes(b"\xef\xbb\xbf" + b'{"name": "BOM"}')
+        result = parse_event(str(event_file))
+        assert result == {"name": "BOM"}
+
 
 class TestInvoke:
     def test_successful_handler(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,86 @@
+"""Tests for the event templates module."""
+
+import pytest
+
+from lambdarunner.templates import get_template, list_templates
+
+
+class TestListTemplates:
+    def test_returns_expected_keys(self):
+        names = [name for name, _ in list_templates()]
+        assert "s3" in names
+        assert "sqs" in names
+        assert "sns" in names
+        assert "eventbridge" in names
+        assert "apigw" in names
+        assert "apigw-v2" in names
+
+    def test_returns_six_templates(self):
+        assert len(list_templates()) == 6
+
+    def test_all_descriptions_non_empty(self):
+        for name, description in list_templates():
+            assert description, f"Template {name!r} has empty description"
+
+
+class TestGetTemplate:
+    def test_s3_structure(self):
+        t = get_template("s3")
+        assert "Records" in t
+        record = t["Records"][0]
+        assert record["eventSource"] == "aws:s3"
+        assert record["eventName"] == "ObjectCreated:Put"
+        assert "bucket" in record["s3"]
+        assert "object" in record["s3"]
+
+    def test_sqs_structure(self):
+        t = get_template("sqs")
+        assert "Records" in t
+        record = t["Records"][0]
+        assert record["eventSource"] == "aws:sqs"
+        assert "body" in record
+        assert "messageId" in record
+
+    def test_sns_structure(self):
+        t = get_template("sns")
+        assert "Records" in t
+        record = t["Records"][0]
+        assert record["EventSource"] == "aws:sns"
+        assert "Sns" in record
+        assert record["Sns"]["Type"] == "Notification"
+
+    def test_eventbridge_structure(self):
+        t = get_template("eventbridge")
+        assert "version" in t
+        assert "source" in t
+        assert "detail-type" in t
+        assert "detail" in t
+        assert t["version"] == "0"
+
+    def test_apigw_structure(self):
+        t = get_template("apigw")
+        assert "httpMethod" in t
+        assert "path" in t
+        assert "requestContext" in t
+        assert t["httpMethod"] == "GET"
+
+    def test_apigw_v2_structure(self):
+        t = get_template("apigw-v2")
+        assert t["version"] == "2.0"
+        assert "routeKey" in t
+        assert "rawPath" in t
+        assert "requestContext" in t
+
+    def test_returns_deep_copy(self):
+        t1 = get_template("s3")
+        t1["Records"][0]["eventSource"] = "mutated"
+        t2 = get_template("s3")
+        assert t2["Records"][0]["eventSource"] == "aws:s3"
+
+    def test_unknown_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown template"):
+            get_template("unknown-source")
+
+    def test_unknown_error_lists_available(self):
+        with pytest.raises(ValueError, match="s3"):
+            get_template("invalid")


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Adds `lambdarunner template [event-type]` command to generate ready-to-use                                                                                                                                       
    AWS event JSON for local handler testing                                                                                                                                                                         
  - Supports 6 event types: `s3`, `sqs`, `sns`, `eventbridge`, `apigw`, `apigw-v2`                                                                                                                                   
  - Templates verified field-by-field against AWS documentation (fixed SNS field                                                                                                                                     
    casing `SigningCertURL`/`UnsubscribeURL`, completed API Gateway v1 `requestContext`                                                                                                                              
    and `identity`, added missing `cookies`/`queryStringParameters`/`pathParameters`/                                                                                                                                
    `stageVariables` to API Gateway v2)                                                                                                                                                                              
  - Fixes `parse_event` to read JSON files with UTF-8 BOM (`utf-8-sig`), enabling                                                                                                                                    
    `lambdarunner template s3 | Out-File -Encoding utf8 event.json` on PowerShell 5                                                                                                                                  
                                                                                                                                                                                                                     
  ## Usage                                                                                                                                                                                                           
                                                                                                                                                                                                                     
  ```bash                                                                                                                                                                                                        
  # List all templates
  lambdarunner template
                                                                                                                                                                                                                     
  # Print to terminal                                                                                                                                                                                                
  lambdarunner template sqs                                                                                                                                                                                          
                                                                                                                                                                                                                     
  # Save and invoke (Bash/Zsh)                                                                                                                                                                                   
  lambdarunner template s3 > event.json                                                                                                                                                                              
  lambdarunner invoke handler.lambda_handler --event event.json                                                                                                                                                      
                                                                                                                                                                                                                     
  # PowerShell 5                                                                                                                                                                                                     
  lambdarunner template s3 | Out-File -Encoding utf8 event.json                                                                                                                                                      
                                                                                                                                                                                                                     
  Test plan                                                                                                                                                                                                      
                                                                                                                                                                                                                     
  - poetry run pytest -v — 63 tests pass                                                                                                                                                                             
  - poetry run ruff check . — no lint errors                                                                                                                                                                         
  - lambdarunner template lists all 6 types in a Rich table                                                                                                                                                          
  - lambdarunner template s3 > /tmp/event.json && python -m json.tool /tmp/event.json parses cleanly                                                                                                                 
  - lambdarunner template unknown exits with code 1 and error message