### PR TITLE
fix: use correct github-actions[bot] identity for bump commits  

### DIFF
--- a/.github/workflows/release_major.yaml
+++ b/.github/workflows/release_major.yaml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml lambdarunner/__init__.py
           git commit -m "bump: v${{ steps.bump.outputs.version }}"
           git tag ${{ steps.bump.outputs.tag }}

--- a/.github/workflows/release_minor.yaml
+++ b/.github/workflows/release_minor.yaml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml lambdarunner/__init__.py
           git commit -m "bump: v${{ steps.bump.outputs.version }}"
           git tag ${{ steps.bump.outputs.tag }}

--- a/.github/workflows/release_patch.yaml
+++ b/.github/workflows/release_patch.yaml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml lambdarunner/__init__.py
           git commit -m "bump: v${{ steps.bump.outputs.version }}"
           git tag ${{ steps.bump.outputs.tag }}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Fixes automated bump commits showing as `invalid-email-address` on GitHub                                                                                                                                        
  - Replaces `github-actions@github.com` (unresolvable) with the official bot                                                                                                                                        
    noreply email in all three release workflows (major, minor, patch)                                                                                                                                               
                                                                                                                                                                                                                     
  ## Root cause                                                                                                                                                                                                      
                                                                                                                                                                                                                     
  `github-actions@github.com` is not associated with any GitHub account, so                                                                                                                                          
  GitHub cannot resolve the committer and displays `invalid-email-address`.                                                                                                                                          
                                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  ```yaml                                                                                                                                                                                                            
  # Before                                                                                                                                                                                                           
  git config user.name "github-actions"                                                                                                                                                                          
  git config user.email "github-actions@github.com"
                                                   
  # After
  git config user.name "github-actions[bot]"
  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                                                                                                                                                                                                                     
  Applies to: release_major.yaml, release_minor.yaml, release_patch.yaml