### PR TITLE
fix: correct bot identity and remove failing set-title step 

### DIFF
--- a/.github/workflows/release_major.yaml
+++ b/.github/workflows/release_major.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   release:
@@ -37,14 +36,6 @@ jobs:
           echo "Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set run title
-        run: |
-          gh api --method PATCH \
-            /repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-            -f display_title="v${{ steps.bump.outputs.version }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Update __init__.py version
         run: |

--- a/.github/workflows/release_minor.yaml
+++ b/.github/workflows/release_minor.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   release:
@@ -37,14 +36,6 @@ jobs:
           echo "Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set run title
-        run: |
-          gh api --method PATCH \
-            /repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-            -f display_title="v${{ steps.bump.outputs.version }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Update __init__.py version
         run: |

--- a/.github/workflows/release_patch.yaml
+++ b/.github/workflows/release_patch.yaml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   release:
@@ -37,14 +36,6 @@ jobs:
           echo "Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set run title
-        run: |
-          gh api --method PATCH \
-            /repos/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-            -f display_title="v${{ steps.bump.outputs.version }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Update __init__.py version
         run: |


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Fixes bump commits showing as `invalid-email-address` on GitHub by using                                                                                                                                         
    the correct `github-actions[bot]` noreply email                                                                                                                                                                  
  - Removes the "Set run title" step that was causing a 404 on every release                                                                                                                                         
    run (GITHUB_TOKEN lacks the `repo` scope required by that API endpoint)                                                                                                                                          
  - Drops the now-unnecessary `actions: write` permission from all three                                                                                                                                             
    release workflows                                                                                                                                                                                                
                                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  | File | Change |                                                                                                                                                                                              
  |------|--------|
  | `release_major.yaml` | Fix bot email, remove set-title step and `actions: write` |
  | `release_minor.yaml` | Fix bot email, remove set-title step and `actions: write` |                                                                                                                               
  | `release_patch.yaml` | Fix bot email, remove set-title step and `actions: write` |                                                                                                                               
                                                                                                                                                                                                                     
  ## Root causes                                                                                                                                                                                                     
                                                                                                                                                                                                                     
  **invalid-email-address:** `github-actions@github.com` is not linked to any                                                                                                                                        
  GitHub account. The correct identity is:                                                                                                                                                                           
  user.name  = github-actions[bot]                                                                                                                                                                                   
  user.email = 41898282+github-actions[bot]@users.noreply.github.com                                                                                                                                                 
                                                                                                                                                                                                                     
  **404 on set-title:** `PATCH /repos/.../actions/runs/{id}` requires OAuth                                                                                                                                          
  `repo` scope. `GITHUB_TOKEN` with `actions: write` does not satisfy this,                                                                                                                                          
  regardless of what the permissions block declares.      